### PR TITLE
Less sinon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - [x] provide `it` and `describe`, and use it at least internally everywhere
 - [x] provide `xit` and `xdescribe`
 - [ ] move to pure `import` (using esm) to not need `require` and be browser compatible
+- [ ] remove sinon

--- a/tests/reporter.spec.js
+++ b/tests/reporter.spec.js
@@ -1,10 +1,10 @@
-import sinon from 'sinon';
 import assert from 'assert';
+import { buildSpy } from './utils.js';
 import { describe, it } from '../lib';
 import { reporter } from '../lib/reporters/index';
 
 const outputDevice = {
-  log: sinon.spy()
+  log: buildSpy()
 };
 const mockedReporter = reporter(outputDevice);
 

--- a/tests/runner.spec.js
+++ b/tests/runner.spec.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import assert from 'assert';
+import { buildSpy } from './utils.js';
 import { describe, it } from '../lib';
 import { runner } from '../lib/runner';
 import { UnitCollector } from '../lib/unit-collector';
@@ -8,7 +9,7 @@ const reporter = {
   step: sinon.spy(),
   result: sinon.spy(),
   log: sinon.spy(),
-  newLine: sinon.spy()
+  newLine: buildSpy()
 };
 
 const process = { exit: sinon.spy() };

--- a/tests/runner.spec.js
+++ b/tests/runner.spec.js
@@ -8,7 +8,7 @@ import { UnitCollector } from '../lib/unit-collector';
 const reporter = {
   step: sinon.spy(),
   result: sinon.spy(),
-  log: sinon.spy(),
+  log: buildSpy(),
   newLine: buildSpy()
 };
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -9,7 +9,7 @@ export const buildSpy = () => {
   spy.wasCalled = false;
   spy.callCount = 0;
   const dumbDeepCompare = (what, args) => ''+what === ''+args;
-  spy.calledWith = (what) =>
+  spy.calledWith = (...what) =>
     calledWith.filter(args => dumbDeepCompare(what, args)).length > 0;
   return spy;
 };


### PR DESCRIPTION
Due to sinon's `calledWith` comparing parts of the parameters, and the internal spy's `calledWith` is not capable of it I didn't replace it yet. It needs to be done somehow simpler.